### PR TITLE
🚨 Turn off linting for all code brought over by legacy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -21,8 +21,20 @@ warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
-[mypy-netspy.*]
-ignore_errors = False
+; Ignore this specify reexport as no type hints
+[mypy-networkx.classes.multidigraph.*]
+ignore_errors = True 
+ignore_missing_imports = True
+
+[mypy-netspy.speech_graph.*]
+ignore_errors = True
+
+[mypy-netspy.visualise_paragraph_functions.*]
+ignore_errors = True
+
+[mypy-netspy.nlp_helper_functions.*]
+ignore_errors = True
+
 
 [mypy-nltk]
 ignore_missing_imports = True

--- a/netspy/__init__.py
+++ b/netspy/__init__.py
@@ -2,11 +2,11 @@
 speech transcripts.
 """
 
+from networkx.classes.multidigraph import MultiDiGraph
+
 from netspy.install_models import install_dependencies
+from netspy.speech_graph import speech_graph
 
 __version__ = "0.1.0"
 
-from netspy.speech_graph import speech_graph
-from netspy.types import MultiDiGraph
-
-__all__ = ["install_dependencies","speech_graph", "MultiDiGraph"]
+__all__ = ["install_dependencies", "speech_graph", "MultiDiGraph"]

--- a/netspy/nlp_helper_functions.py
+++ b/netspy/nlp_helper_functions.py
@@ -5,6 +5,8 @@ Created on Wed Dec 18 15:07:59 2019
 @author: Dr Sarah E Morgan, with input from Dr Bo Wang
 modified by Dr. Caro Nettekoven, 2020
 """
+# flake8: noqa
+# pylint: skip-file
 
 # from __future__ import division
 import itertools

--- a/netspy/speech_graph.py
+++ b/netspy/speech_graph.py
@@ -14,6 +14,8 @@
 #        tat=3; python -u ./speech_graph.py ${tat} > figures/SpeechGraph_log_${tat}_`date +%F` # (pipe output to text file)
 # ------------------------------------------------------------------------------
 
+# flake8: noqa
+# pylint: skip-file
 
 import datetime
 import os
@@ -74,9 +76,9 @@ from netspy.visualise_paragraph_functions import (
     split_nodes,
 )
 
-# Install packages
-nltk.download("punkt")
-stanza.install_corenlp()
+# # Install packages
+# nltk.download("punkt")
+# stanza.install_corenlp()
 
 
 def speech_graph(transcript: str) -> MultiDiGraph:

--- a/netspy/types.py
+++ b/netspy/types.py
@@ -1,4 +1,3 @@
-from networkx.classes.multidigraph import MultiDiGraph
 from enum import Enum
 
 

--- a/netspy/visualise_paragraph_functions.py
+++ b/netspy/visualise_paragraph_functions.py
@@ -12,6 +12,9 @@
 # source /Users/CN/Documents/Projects/Cambridge/cambridge_language_analysis/venv/bin/activate
 # TODO: Sanity check: Is each relation represented only once in the edge? (Also check parallel edges in multiedge graph)
 # TODO: Plot graphs coloured by confidence / extraction type
+# flake8: noqa
+# pylint: skip-file
+
 import os
 import os.path as op
 import sys

--- a/tests/test_netspy.py
+++ b/tests/test_netspy.py
@@ -1,8 +1,8 @@
 # pylint: disable=C0114, C0116
-import netspy
+
 from netspy import __version__
 from netspy.speech_graph import plot_graph, speech_graph
-
+from typing import Dict, Any
 
 def test_version() -> None:
     assert __version__ == "0.1.0"
@@ -287,7 +287,7 @@ def test_speech_graph() -> None:
         "unconnected_nodes": ["lighting", "way", "woman"],
     }
 
-    expected_dict_node4 = {
+    expected_dict_node4: Dict[str, Dict[Any, Any]] = {
         "image": {},
         "pretty boring": {},
         "child": {},


### PR DESCRIPTION


### Overview
<!-- What does this PR do -->

Turn off pylint, flake8 and mypy linter warnings for all code brought in by legacy., which can be fixed in another PR (issue - https://github.com/alan-turing-institute/netspy/issues/65)

### Closes
<!-- List of issues this closes -->
- Closes ####

### Checks
- [ ] Have you added unit tests?
- [ ] Have you added documentation?
- [ ] Are all tests and linting passing?

### Information for reviewer
<!-- Anything the reviewer should pay attention to. Include information on how to check your code (e.g. what commands to run). -->
