### PR TITLE
Only run slow unit tests on PRs to main

### DIFF
--- a/.github/workflows/fast-unit-tests.yml
+++ b/.github/workflows/fast-unit-tests.yml
@@ -1,4 +1,4 @@
-name: unit-tests
+name: fast-unit-tests
 on: [pull_request]
 jobs:
   run:
@@ -51,32 +51,7 @@ jobs:
     - name: Display Python version
       run: poetry run python -c "import sys; print(sys.version)"
 
+    # ToDo Add code coverage to these tests?
     - name: Run tests which can't use netspy cache
       run: |
         python -m poetry run pytest tests -m "not slow and without_cache"
-
-    # Cache netspy dependencies except openie (cache too big)
-    - name: Set up netspy cache
-      uses: actions/cache@v2
-      id: netspy-dependencies
-      with:
-        path: |
-          .dependencies/nltk_data/*
-          .dependencies/stanza_corenlp/*
-          .dependencies/openie/*
-          !.dependencies/openie/openie-assembly-5.0-SNAPSHOT.jar
-        key: netspy-dependencies
-
-    - name: Install netspy dependencies
-      shell: bash
-      run: |
-        python -m poetry run netspy install
-
-    - name: Generate Report
-      run: |
-        python -m poetry run pytest --cov=netspy --cov-report=xml tests -m "not slow and not without_cache"
-
-    - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/slow-unit-tests.yml
+++ b/.github/workflows/slow-unit-tests.yml
@@ -1,0 +1,82 @@
+name: slow-unit-tests
+on:
+  # Only runs on PRs to main
+  pull_request:
+    branches:
+      - main
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.7]
+      fail-fast: false
+    env:
+      # Set the location of netspy dependencies
+      NETSPY_DIR: '.dependencies'
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Bootstrap poetry
+      shell: bash
+      run: |
+        python -m ensurepip
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+
+    - name: Configure poetry
+      shell: bash
+      run: |
+        python -m poetry config virtualenvs.in-project true
+        python -m poetry config virtualenvs.create true
+
+    - name: Set up cache
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m poetry env use ${{ matrix.python-version }}
+        python -m poetry install
+
+    - name: Display Python version
+      run: poetry run python -c "import sys; print(sys.version)"
+
+    # Cache netspy dependencies except openie (cache too big)
+    - name: Set up netspy cache
+      uses: actions/cache@v2
+      id: netspy-dependencies
+      with:
+        path: |
+          .dependencies/nltk_data/*
+          .dependencies/stanza_corenlp/*
+          .dependencies/openie/*
+          !.dependencies/openie/openie-assembly-5.0-SNAPSHOT.jar
+        key: netspy-dependencies
+
+    - name: Install netspy dependencies
+      shell: bash
+      run: |
+        python -m poetry run netspy install
+
+    - name: Generate Report
+      run: |
+        python -m poetry run pytest --cov=netspy --cov-report=xml tests -m "not slow and not without_cache"
+
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Overview

This way, you can choose to have PRs to e.g. a dev/release candidate
branch where the fast unit tests run but the slow ones don't, to
conserve GitHub minutes and allow merging more quickly (as the slow
ones take > 20 minutes).

### Checks
- [x] Have you added unit tests?
- [ ] Have you added documentation?
- [x] Are all tests and linting passing?

### Information for reviewer

Are there other ways we might want to accomplish this? E.g. have a slow workflow that we need to [manually run](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) or run the fast tests (fast unit tests and pre-commit tests) on every push and the slow ones only on PRs.