### PR TITLE
Don't (GitHub) cache the OpenIE language model

### DIFF
--- a/.github/workflows/slow-unit-tests.yml
+++ b/.github/workflows/slow-unit-tests.yml
@@ -60,11 +60,11 @@ jobs:
       uses: actions/cache@v2
       id: netspy-dependencies
       with:
+        # Don't cache the openie language model as it alone is > 5GB
         path: |
           .dependencies/nltk_data/*
           .dependencies/stanza_corenlp/*
-          .dependencies/openie/*
-          !.dependencies/openie/openie-assembly-5.0-SNAPSHOT.jar
+          .dependencies/openie/openie-assembly-5.0-SNAPSHOT.jar
         key: netspy-dependencies
 
     - name: Install netspy dependencies


### PR DESCRIPTION
The language model alone is 6GB and means that the cache action
doesn't work. The other folders should come in at under 5GB:

.venv ~ 1.2GB
stanza ~ 0.5GB
openie ~ 1.8GB
nltk ~ 50MB

total ~ 3.55GB
